### PR TITLE
Change server to use typescript and use generated swagger models

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "e2e": "npm run swagger && ng e2e",
     "clean": "rimraf ./src/swagger-data && rimraf ./documentation",
     "swagger": "java -jar ./swagger/swagger-codegen-cli.jar generate -i ./swagger/swagger.json -l typescript-angular2 -t ./swagger -o ./src/swagger-data",
-    "example-data": "ts-node ./server/index.ts",
+    "example-data": "npm run clean && npm run swagger && ts-node ./server/index.ts",
     "documentation": "java -jar ./swagger/swagger-codegen-cli.jar generate -i ./swagger/swagger.json -l html2 -o ./documentation && http-server ./documentation"
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "e2e": "npm run swagger && ng e2e",
     "clean": "rimraf ./src/swagger-data && rimraf ./documentation",
     "swagger": "java -jar ./swagger/swagger-codegen-cli.jar generate -i ./swagger/swagger.json -l typescript-angular2 -t ./swagger -o ./src/swagger-data",
-    "example-data": "node ./server/index.js",
+    "example-data": "ts-node ./server/index.ts",
     "documentation": "java -jar ./swagger/swagger-codegen-cli.jar generate -i ./swagger/swagger.json -l html2 -o ./documentation && http-server ./documentation"
   },
   "private": true,
@@ -24,6 +24,7 @@
     "@angular/platform-browser": "^4.0.0",
     "@angular/platform-browser-dynamic": "^4.0.0",
     "@angular/router": "^4.0.0",
+    "@types/express": "^4.0.35",
     "core-js": "^2.4.1",
     "rxjs": "^5.1.0",
     "zone.js": "^0.8.4"

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,4 @@
-import { Pet, DetailedPet } from 'swagger-data/model/models';
+import { Pet, DetailedPet } from 'swagger-data';
 import * as express from 'express';
 const app = express();
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,29 +1,30 @@
-const express = require('express');
+import { Pet, DetailedPet } from 'swagger-data/model/models';
+import * as express from 'express';
 const app = express();
 
-function getPet(id) {
+function getPet(id: number): Pet {
     return {
         id,
         name: `Pet Name ${id}`,
-        createdAt: new Date(),
+        createdAt: (new Date()).toString(),
         type: 'Pet'
     };
 }
 
 app.get('/api/pet', (req, res) => {
-    const limit = req.query.limit || 10;
-    const pets = [];
+    const limit: number = req.query.limit || 10;
+    const pets: Pet[] = [];
 
     for (let x = 0; x < limit; x++) {
-        pets.push(getPet(x+1));
+        pets.push(getPet(x + 1));
     }
 
-    res.send(pets)
+    res.send(pets);
 });
 
 app.get('/api/pet/:petId', (req, res) => {
-    const petId = req.params.petId;
-    const pet = getPet(petId);
+    const petId: number = req.params.petId;
+    const pet = getPet(petId) as DetailedPet;
     pet.description = 'This is a really long description for a pet. ' +
         'This is a really long description for a pet. This is a ' +
         'really long description for a pet.';
@@ -35,5 +36,5 @@ app.get('/api/pet/:petId', (req, res) => {
 });
 
 app.listen(3500, () => {
-  console.log('Example server listening on port 3500...')
+  console.log('Example server listening on port 3500...');
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -125,11 +125,28 @@
     magic-string "^0.19.0"
     source-map "^0.5.6"
 
+"@types/express-serve-static-core@*":
+  version "4.0.45"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.0.45.tgz#71bb1f87d7187482d0d8851f5b294458e1c78667"
+  dependencies:
+    "@types/node" "*"
+
+"@types/express@^4.0.35":
+  version "4.0.35"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.0.35.tgz#6267c7b60a51fac473467b3c4a02cd1e441805fe"
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/serve-static" "*"
+
 "@types/jasmine@2.5.38":
   version "2.5.38"
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.5.38.tgz#a4379124c4921d4e21de54ec74669c9e9b356717"
 
-"@types/node@^6.0.46", "@types/node@~6.0.60":
+"@types/mime@*":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-0.0.29.tgz#fbcfd330573b912ef59eeee14602bface630754b"
+
+"@types/node@*", "@types/node@^6.0.46", "@types/node@~6.0.60":
   version "6.0.73"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.73.tgz#85dc4bb6f125377c75ddd2519a1eeb63f0a4ed70"
 
@@ -140,6 +157,13 @@
 "@types/selenium-webdriver@^2.53.35", "@types/selenium-webdriver@~2.53.39":
   version "2.53.42"
   resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-2.53.42.tgz#74cb77fb6052edaff2a8984ddafd88d419f25cac"
+
+"@types/serve-static@*":
+  version "1.7.31"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.7.31.tgz#15456de8d98d6b4cff31be6c6af7492ae63f521a"
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/mime" "*"
 
 abbrev@1:
   version "1.1.0"


### PR DESCRIPTION
To get my feet wet, I thought it might be nice if we could also get some of the same type safety on the server. I kept it simple by just using the models that are already being generated for the client code, so there's still no type safety around the actual request/response objects. It's also probably a little gross that the server is reaching into the client code, but I figure it's probably fine for a demo ;). Let me know what you think!